### PR TITLE
Resolve Issue:#9

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -214,10 +214,20 @@ a {
     line-height: 15px;
     margin: 0 auto;
   }
+
+  .navbar {
+    position: fixed;
+    top: 0px;
+    width: 100%;
+    background-color: #ffffff;
+    z-index: 1;
+    margin-left: 0;
+  }
+
   .nav-menu {
     position: fixed;
     left: -100%;
-    top: 5rem;
+    top: 2.8125rem;
     flex-direction: column;
     width: 100%;
     text-align: center;
@@ -229,10 +239,11 @@ a {
 
   .nav-menu.active {
     left: 0;
+    background-color: #ffffff;
   }
 
   .nav-item {
-    margin: 25px 0;
+    margin: 0;
   }
 
   .hamburger {


### PR DESCRIPTION
 fix: Navbar overlap on-scroll in mobile view

<!--- Provide a short summary of your changes in the Title -->

## Summary
<!--- Describe the changes in more detail. Feel free to include screenshots if relevant. -->
In mobile view, the landing-page navbar was overlapped by the page content on-scroll. 

- The position of the navbar has been changed to fixed, as we have to keep the navbar fixed even on-scroll.
- The background color for the navbar and nav-menu was not given, which I changed to white as of now. 
- The z-index is increased as the card section was overlapping the navbar.



## Motivation
<!--- Why have you made this Pull Request? Does this fix an open issue? -->
This pull request fixes the open [issue#9](https://github.com/camicroscope/camicroscope.github.io/issues/9) .
## Testing
<!--- Has this been tested beyond the automatic hooks? How so? -->

Have tested the changes locally.

![screen__capture](https://user-images.githubusercontent.com/63798770/117534220-19929680-b00e-11eb-9381-2edc726b4cd5.gif)


## Questions
<!--- Are there any aspects you're unsure about? Are you looking for any feedback? -->
The background color of the navbar has been given white as of now, but we can change that according to the UX.
 <!--- Mark a pull request as a draft to signal that it is not ready for review. -->
