### PR TITLE
Changed links of navbar

### DIFF
--- a/community.html
+++ b/community.html
@@ -55,7 +55,7 @@ http://www.templatemo.com/tm-517-timeless
   <body style="background-color: #fcfcfc">
     <nav class="navbar">
       <div class="container">
-        <a href="#" class="nav-logo logo__color">caMicroscope</a>
+        <a href="index.html" class="nav-logo logo__color">caMicroscope</a>
         <ul class="nav-menu">
           <li class="nav-item">
             <a

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ http://www.templatemo.com/tm-517-timeless
     <div class="main-conatiner">
     <nav class="navbar">
       <div class="container">
-        <a href="#" class="nav-logo logo__color">caMicroscope</a>
+        <a href="index.html" class="nav-logo logo__color">caMicroscope</a>
         <ul class="nav-menu">
           <li class="nav-item">
             <a href="#features" class="nav-link">Features</a>
@@ -97,7 +97,7 @@ http://www.templatemo.com/tm-517-timeless
       class="img-fluid banner__image__center"
       alt="Responsive image"
     />
-    <div class="section__header__main" id="features">
+    <div class="section__header__main">
       <p>
         A perfect tool,
         <span class="logo__color">for your Digital Pathology.</span>
@@ -119,7 +119,8 @@ http://www.templatemo.com/tm-517-timeless
         optimize the disk space needed to manage these large images.
       </p>
     </div>
-    <div style="margin-top: 98px">
+    <div name="features" id="features">
+    <div style="margin-top: 98px" name="features" id="features">
       <div class="container">
         <div class="row">
           <div class="col-lg-4 col-sm-12 col-md-6">


### PR DESCRIPTION
On clicking the "caMicroscope" word in the navbar, the user was redirected to "#". On clicking the feature link in the navbar, the user wasn't navigated to the features part. I have fixed both in this pr.

I changed the link from "#" to index.html so that the user will be redirected to the landing page. I fixed the feature link issue too.

Before:

[before.webm](https://user-images.githubusercontent.com/84843461/223022437-d88fcff7-c2df-448e-b251-65bb7855ee78.webm)

After:

[after.webm](https://user-images.githubusercontent.com/84843461/223022462-f1eac38a-49da-4a25-b983-1dae2ad15e34.webm)
