### PR TITLE
[Typo] Fixed typo in Community and Contributing pages

### DIFF
--- a/community.html
+++ b/community.html
@@ -70,7 +70,7 @@ http://www.templatemo.com/tm-517-timeless
         <div class="section__content__main">
           <p> We're thrilled to have you as part of the caMicroscope community. Whether you're a developer, researcher, or simply interested in our open-source project, you're a valuable member of our community. </p>
           <h2>Software Project Roadmap</h2>
-          <p> The <a href="./roadmap.html">Roadmap Document</a> higlights an overall plan for the future of caMicroscope is a good place to learn about which kinds of support are most needed.</p>
+          <p> The <a href="./roadmap.html">Roadmap Document</a> highlights an overall plan for the future of caMicroscope. It is a good place to learn about which kinds of support are most needed.</p>
           <h2>Code of Conduct</h2>
           <p> To ensure a welcoming and inclusive environment for all community members, we have a <a href="./conduct.html">Code of Conduct</a>. We ask that you familiarize yourself with it and abide by its principles while participating in the community. </p>
           <h2>Governance</h2>

--- a/contributing.html
+++ b/contributing.html
@@ -161,7 +161,7 @@ http://www.templatemo.com/tm-517-timeless
         <h3 id="code-of-conduct">Code of Conduct</h3>
         <p>We have a Code of Conduct in place to create a respectful and inclusive environment for all contributors. Please read and adhere to the <a href="./conduct.html">Code of Conduct</a> when participating in caMicroscope development. </p>
         <h3>Software Project Roadmap</h3>
-        <p> The <a href="./roadmap.html">Roadmap Document</a> higlights an overall plan for the future of caMicroscope is a good place to learn about which kinds of support are most needed.</p>  
+        <p> The <a href="./roadmap.html">Roadmap Document</a> highlights an overall plan for the future of caMicroscope. It is a good place to learn about which kinds of support are most needed.</p>  
         <h3 id="licensing">Licensing</h3>
         <p>caMicroscope is licensed under the open source <a href="https://github.com/camicroscope/caMicroscope/blob/master/LICENSE">BSD 3-Clause License</a> unless otherwise specified in a repository, and contributions are subject to the same license terms. Make sure you are comfortable with the licensing terms before contributing. </p>
         <h3 id="recognition">Recognition</h3>


### PR DESCRIPTION
Fixed the typo and grammatical errors in the Software Project Roadmap section.

## Summary
![image](https://github.com/camicroscope/camicroscope.github.io/assets/122698422/629825ea-1701-403f-9518-76bee09faaff)

## Motivation
I noticed the errors while going through the docs. There's no open issue around this.
